### PR TITLE
Disable PTB JobQueue creation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1641,7 +1641,15 @@ async def stats_read_choose_floor(update: Update, context: ContextTypes.DEFAULT_
 def build_ptb_app() -> Application:
     if not TOKEN:
         raise RuntimeError("TELEGRAM_BOT_TOKEN не задан в окружении")
-    app = Application.builder().token(TOKEN).updater(None).build()
+    app = (
+        Application.builder()
+        .token(TOKEN)
+        .job_queue(None)
+        .updater(None)
+        .build()
+    )
+
+    assert app.job_queue is None, "PTB Application must not create JobQueue in webhook mode"
 
     # Команды
     app.add_handler(CommandHandler("start", start))


### PR DESCRIPTION
## Summary
- prevent the PTB Application builder from creating an implicit JobQueue when running in webhook mode
- assert that the resulting Application has no JobQueue to catch regressions early

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68df6aa0fd6c8326b00bbaf91077d7c1