### PR TITLE
Shorten meter code header

### DIFF
--- a/main.py
+++ b/main.py
@@ -611,7 +611,7 @@ def build_submission_card_html(raw_readings: dict) -> str:
             return "—"
         return escape(str(val))
 
-    header = "Шифра мерног места"
+    header = "Шифра м. м."
     table_lines = [
         f"{header:<20} {'ВТ':>8} {'НТ':>8}",
     ]


### PR DESCRIPTION
## Summary
- shorten the meter code column header to "Шифра м. м." so the table fits a narrower column

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df910a20e4832689ad3ace3ade5bd0